### PR TITLE
确保 ClashXW 退出时同步终止 mihomo 进程

### DIFF
--- a/Native/NativeMethods.cs
+++ b/Native/NativeMethods.cs
@@ -3,8 +3,6 @@ using System.Runtime.InteropServices;
 
 namespace ClashXW.Native
 {
-    
-
     internal delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
 
     internal static class NativeMethods
@@ -45,6 +43,47 @@ namespace ClashXW.Native
             public POINT ptMinPosition;
             public POINT ptMaxPosition;
             public RECT rcNormalPosition;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct IO_COUNTERS
+        {
+            public ulong ReadOperationCount;
+            public ulong WriteOperationCount;
+            public ulong OtherOperationCount;
+            public ulong ReadTransferCount;
+            public ulong WriteTransferCount;
+            public ulong OtherTransferCount;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+        {
+            public long PerProcessUserTimeLimit;
+            public long PerJobUserTimeLimit;
+            public uint LimitFlags;
+            public UIntPtr MinimumWorkingSetSize;
+            public UIntPtr MaximumWorkingSetSize;
+            public uint ActiveProcessLimit;
+            public UIntPtr Affinity;
+            public uint PriorityClass;
+            public uint SchedulingClass;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+            public IO_COUNTERS IoInfo;
+            public UIntPtr ProcessMemoryLimit;
+            public UIntPtr JobMemoryLimit;
+            public UIntPtr PeakProcessMemoryUsed;
+            public UIntPtr PeakJobMemoryUsed;
+        }
+
+        internal enum JOBOBJECTINFOCLASS
+        {
+            JobObjectExtendedLimitInformation = 9
         }
 
         // ShowWindow commands
@@ -112,6 +151,25 @@ namespace ClashXW.Native
         [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern uint GetCurrentThreadId();
 
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string? lpName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool SetInformationJobObject(
+            IntPtr hJob,
+            JOBOBJECTINFOCLASS JobObjectInfoClass,
+            IntPtr lpJobObjectInfo,
+            uint cbJobObjectInfoLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool CloseHandle(IntPtr hObject);
+
         // Keyboard state
         [DllImport("user32.dll")]
         internal static extern short GetKeyState(int nVirtKey);
@@ -149,5 +207,8 @@ namespace ClashXW.Native
         // Virtual key codes
         internal const int VK_CONTROL = 0x11;
         internal const int VK_MENU = 0x12; // Alt key
+
+        // Job object limit flags
+        internal const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
     }
 }

--- a/Services/ClashProcessService.cs
+++ b/Services/ClashProcessService.cs
@@ -1,6 +1,9 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
+using ClashXW.Native;
 
 namespace ClashXW.Services
 {
@@ -8,6 +11,7 @@ namespace ClashXW.Services
     {
         private Process? _clashProcess;
         private readonly string _executablePath;
+        private IntPtr _jobHandle;
 
         public ClashProcessService(string executablePath)
         {
@@ -42,18 +46,22 @@ namespace ClashXW.Services
 
                 _clashProcess = new Process { StartInfo = startInfo };
                 _clashProcess.Start();
+                AssignToLifetimeJob(_clashProcess);
             }
             catch (Exception ex)
             {
+                CleanupFailedStart();
                 throw new InvalidOperationException($"Failed to start Clash process: {ex.Message}", ex);
             }
         }
 
         public void Stop()
         {
+            ReleaseLifetimeJob();
+
             if (_clashProcess != null && !_clashProcess.HasExited)
             {
-                _clashProcess.Kill();
+                KillProcessBestEffort(_clashProcess, "stop");
             }
         }
 
@@ -63,6 +71,109 @@ namespace ClashXW.Services
         {
             Stop();
             _clashProcess?.Dispose();
+        }
+
+        private void AssignToLifetimeJob(Process process)
+        {
+            var jobHandle = EnsureLifetimeJob();
+            if (!NativeMethods.AssignProcessToJobObject(jobHandle, process.Handle))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "AssignProcessToJobObject failed");
+            }
+
+            Logger.Info($"Assigned Clash core PID={process.Id} to lifetime job");
+        }
+
+        private IntPtr EnsureLifetimeJob()
+        {
+            if (_jobHandle != IntPtr.Zero)
+            {
+                return _jobHandle;
+            }
+
+            var jobHandle = NativeMethods.CreateJobObject(IntPtr.Zero, null);
+            if (jobHandle == IntPtr.Zero)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "CreateJobObject failed");
+            }
+
+            var limits = new NativeMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+            {
+                BasicLimitInformation = new NativeMethods.JOBOBJECT_BASIC_LIMIT_INFORMATION
+                {
+                    LimitFlags = NativeMethods.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+                }
+            };
+
+            var size = Marshal.SizeOf<NativeMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION>();
+            var limitsPtr = Marshal.AllocHGlobal(size);
+
+            try
+            {
+                Marshal.StructureToPtr(limits, limitsPtr, false);
+                if (!NativeMethods.SetInformationJobObject(
+                        jobHandle,
+                        NativeMethods.JOBOBJECTINFOCLASS.JobObjectExtendedLimitInformation,
+                        limitsPtr,
+                        (uint)size))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), "SetInformationJobObject failed");
+                }
+            }
+            catch
+            {
+                NativeMethods.CloseHandle(jobHandle);
+                throw;
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(limitsPtr);
+            }
+
+            _jobHandle = jobHandle;
+            return _jobHandle;
+        }
+
+        private void CleanupFailedStart()
+        {
+            ReleaseLifetimeJob();
+
+            if (_clashProcess != null)
+            {
+                KillProcessBestEffort(_clashProcess, "startup rollback");
+                _clashProcess.Dispose();
+                _clashProcess = null;
+            }
+        }
+
+        private void KillProcessBestEffort(Process process, string context)
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"Failed to kill Clash core during {context}: {ex.Message}");
+            }
+        }
+
+        private void ReleaseLifetimeJob()
+        {
+            if (_jobHandle == IntPtr.Zero)
+            {
+                return;
+            }
+
+            if (!NativeMethods.CloseHandle(_jobHandle))
+            {
+                Logger.Warn($"Failed to close Clash lifetime job handle: {Marshal.GetLastWin32Error()}");
+            }
+
+            _jobHandle = IntPtr.Zero;
         }
     }
 }


### PR DESCRIPTION
## 问题

mihomo 在调用 \/restart 接口后，可能会以新的进程继续运行。

ClashXW 此前仅持有首次启动时的进程句柄，因此在这种情况下，ClashXW 退出时终止的可能只是旧进程，重启后的 mihomo 仍会留在后台继续运行。

## 修改

本次修改将 mihomo 纳入 Windows Job Object 管理，并启用 `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`。

同时，启动阶段若 Job 创建或进程绑定失败，将直接视为启动失败，并回滚已启动的 mihomo 进程；退出阶段则保持为尽力清理，仅记录异常，不使清理失败影响程序正常退出。

## 结果

在 mihomo 运行期间即使发生 \/restart，只要其仍属于该 Job，ClashXW 退出时系统便会一并回收相关进程，不再出现 core 在后台残留的情况。